### PR TITLE
ランチの削除を行う

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -22,6 +22,11 @@ class LunchesController < ApplicationController
     end
   end
 
+  def destroy
+    Lunch.find(params[:id]).delete
+    redirect_to lunches_path
+  end
+
   private
 
   def lunch_params

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -23,7 +23,7 @@ class LunchesController < ApplicationController
   end
 
   def destroy
-    Lunch.find(params[:id]).delete
+    Lunch.find(params[:id]).destroy
     redirect_to lunches_path
   end
 

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,7 +1,7 @@
 class Lunch < ApplicationRecord
   belongs_to :user
   has_one :topic, dependent: :destroy
-  has_many :invitations
+  has_many :invitations, dependent: :destroy
   has_many :invitees, through: :invitations, source: :user
   validates :state, presence: true
   validates :user_id, presence: true

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -12,10 +12,10 @@
   <% end %>
   <% if @lunch.topic.present? %>
     <p>話したこと</p>
-    <p><%= @lunch.topic.description.to_s %>
+    <p><%= @lunch.topic.description.to_s %></p>
   <% end %>
   <div>
     <%= link_to "予定を削除", @lunch, method: :delete,
-                                data: { confirm: "後悔しませんか？" } %>
+                                      data: { confirm: "後悔しませんか？" } %>
   </div>
 </div>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -16,6 +16,6 @@
   <% end %>
   <div>
     <%= link_to "予定を削除", @lunch, method: :delete,
-                                      data: { confirm: "後悔しませんか？" } %>
+                                    data: { confirm: "後悔しませんか？" } %>
   </div>
 </div>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <% if @lunch.topic.present? %>
     <p>話したこと</p>
-    <p><%= @lunch.topic.description.to_s %></p>
+    <p><%= @lunch.topic.description %></p>
   <% end %>
   <div>
     <%= link_to "予定を削除", @lunch, method: :delete, data: { confirm: "後悔しませんか？" } %>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -15,7 +15,6 @@
     <p><%= @lunch.topic.description.to_s %></p>
   <% end %>
   <div>
-    <%= link_to "予定を削除", @lunch, method: :delete,
-                                    data: { confirm: "後悔しませんか？" } %>
+    <%= link_to "予定を削除", @lunch, method: :delete, data: { confirm: "後悔しませんか？" } %>
   </div>
 </div>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -14,5 +14,8 @@
     <p>話したこと</p>
     <p><%= @lunch.topic.description.to_s %>
   <% end %>
+  <div>
+    <%= link_to "予定を削除", @lunch, method: :delete,
+                                data: { confirm: "後悔しませんか？" } %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :lunches, only: %i[index show new create]
+  resources :lunches, only: %i[index show new create destroy]
 end


### PR DESCRIPTION
# ランチの予定の削除ができるようになります。
fixes #10 

## やること
- [x] 予定の詳細に削除リンクを追加する
- [x] `destroy`アクションを実装する

## やらないこと
- [x] デザイン
- [x] stateの状態遷移
- [x] 権限の設定(このPRではすべてのユーザがランチの予定を削除できます)

## レビュアー
だれでも

1名以上のapproveでマージします。