### PR TITLE
ランチの予定を編集する

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -40,7 +40,7 @@ class LunchesController < ApplicationController
   private
 
   def set_lunch
-    @lunch = Lunch.find_by(id: params[:id])
+    @lunch = Lunch.find(params[:id])
   end
 
   def lunch_params

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,13 +1,11 @@
 class LunchesController < ApplicationController
-  before_action :set_lunch, only: %i[edit update destroy]
+  before_action :set_lunch, only: %i[show edit update destroy]
 
   def index
     @lunches = Lunch.all
   end
 
-  def show
-    @lunch = Lunch.find_by(id: params[:id])
-  end
+  def show; end
 
   def new
     @lunch = Lunch.new(scheduled_for: Date.today)

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -22,6 +22,19 @@ class LunchesController < ApplicationController
     end
   end
 
+  def edit
+    @lunch = Lunch.find_by(id: params[:id])
+  end
+
+  def update
+    @lunch = Lunch.find_by(id: params[:id])
+    if @lunch.update_attributes(lunch_params)
+      redirect_to @lunch
+    else
+      render 'edit'
+    end
+  end
+
   def destroy
     Lunch.find(params[:id]).destroy
     redirect_to lunches_path

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,4 +1,6 @@
 class LunchesController < ApplicationController
+  before_action :set_lunch, only: %i[edit update destroy]
+
   def index
     @lunches = Lunch.all
   end
@@ -22,12 +24,9 @@ class LunchesController < ApplicationController
     end
   end
 
-  def edit
-    @lunch = Lunch.find_by(id: params[:id])
-  end
+  def edit; end
 
   def update
-    @lunch = Lunch.find_by(id: params[:id])
     if @lunch.update_attributes(lunch_params)
       redirect_to @lunch
     else
@@ -36,11 +35,15 @@ class LunchesController < ApplicationController
   end
 
   def destroy
-    Lunch.find(params[:id]).destroy
+    @lunch.destroy
     redirect_to lunches_path
   end
 
   private
+
+  def set_lunch
+    @lunch = Lunch.find_by(id: params[:id])
+  end
 
   def lunch_params
     params.require(:lunch).permit(:scheduled_for, :place)

--- a/app/views/lunches/edit.html.erb
+++ b/app/views/lunches/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", lunch: @lunch %>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -15,6 +15,9 @@
     <p><%= @lunch.topic.description %></p>
   <% end %>
   <div>
+    <%= link_to "予定を編集", edit_lunch_path %>
+  </div>
+  <div>
     <%= link_to "予定を削除", @lunch, method: :delete, data: { confirm: "後悔しませんか？" } %>
   </div>
 </div>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -15,7 +15,7 @@
     <p><%= @lunch.topic.description %></p>
   <% end %>
   <div>
-    <%= link_to "予定を編集", edit_lunch_path %>
+    <%= link_to "予定を編集", edit_lunch_path(@lunch) %>
   </div>
   <div>
     <%= link_to "予定を削除", @lunch, method: :delete, data: { confirm: "後悔しませんか？" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :lunches, only: %i[index show new create destroy]
+  resources :lunches
 end


### PR DESCRIPTION
# ランチの予定を編集可能にします
ランチの編集画面を用意し、ランチの予定を編集できるようにします。  
この編集した内容をDBに反映できるようにします。
  
### 👇編集リンクの追加
<img width="322" alt="cocktailrecipe" src="https://user-images.githubusercontent.com/2727257/44441105-ef061280-a605-11e8-8b4f-be6d95a421be.png">


## やること

- [x] 予定の詳細画面に編集リンクを追加する
- [x] 編集画面で編集した内容をDBに反映する。
- [x] `Lunch#edit` , ` Lunch#update` のルーティングを生やす


## やらないこと

- [x] デザインについてはまだ考えない
- [x] 話題、招待者の編集についてはまだ考えない
- [x]  `_form.html.erb`を新規画面と編集画面で共有することになるが、この区別は別PRで行うことにする

## 見ていただきたいところ

- 冗長な書き方をしていないか。

## レビュアー

どなたでも

## マージ条件
レビュアー１人以上のapprove。
