### PR TITLE
User has_many Lunchesの関連を剥がす

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -9,12 +9,10 @@ class LunchesController < ApplicationController
 
   def new
     @lunch = Lunch.new(scheduled_for: Date.today)
-    @lunch.user = current_user
   end
 
   def create
     @lunch = Lunch.new(lunch_params)
-    @lunch.user = current_user
     if @lunch.save
       redirect_to lunches_path
     else

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,4 +1,4 @@
-class Invitation < ApplicationRecord
+class Attendance < ApplicationRecord
   belongs_to :lunch
   belongs_to :user
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,5 +1,4 @@
 class Lunch < ApplicationRecord
-  belongs_to :user
   has_one :topic, dependent: :destroy
   has_many :attendances, dependent: :destroy
   has_many :attendees, through: :attendances, source: :user

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -7,7 +7,7 @@ class Lunch < ApplicationRecord
 
   enum state: {scheduled: 0, done: 1, canceled: 2}
 
-  def invite(invitee)
-    attendances.create(user: invitee)
+  def attend(attendee)
+    attendances.create(user: attendee)
   end
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,14 +1,14 @@
 class Lunch < ApplicationRecord
   belongs_to :user
   has_one :topic, dependent: :destroy
-  has_many :invitations, dependent: :destroy
-  has_many :invitees, through: :invitations, source: :user
+  has_many :attendances, dependent: :destroy
+  has_many :attendees, through: :attendances, source: :user
   validates :state, presence: true
   validates :scheduled_for, presence: true
 
   enum state: {scheduled: 0, done: 1, canceled: 2}
 
   def invite(invitee)
-    invitations.create(user: invitee)
+    attendances.create(user: invitee)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  has_many :lunches, dependent: :destroy
+  has_many :attendances, dependent: :destory
+  has_many :lunches, through: :attendances
   validates :name, presence: true
   validates :admin, inclusion: {in: [true,false]}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :attendances, dependent: :destory
+  has_many :attendances, dependent: :destroy
   has_many :lunches, through: :attendances
   validates :name, presence: true
   validates :admin, inclusion: {in: [true,false]}

--- a/app/views/lunches/_form.html.erb
+++ b/app/views/lunches/_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_with model: lunch, local: true do |f| %>
   <div>
-    <%= f.label "主催者" %>
-    <%= lunch.user.name %>
+    <%= f.label "参加者" %>
+    <% lunch.attendees.each do |attendee| %>
+      <%= attendee.name %>
+    <% end %>
   </div>
   <div>
     <%= f.label "予定日" %>

--- a/app/views/lunches/_lunch.html.erb
+++ b/app/views/lunches/_lunch.html.erb
@@ -1,6 +1,5 @@
 <li>
   <p><%= lunch.scheduled_for %></p>
-  <p><%= lunch.user.name %></p>
   <% lunch.attendees.each do |attendee| %>
     <p><%= attendee.name %></p>
   <% end %>

--- a/app/views/lunches/_lunch.html.erb
+++ b/app/views/lunches/_lunch.html.erb
@@ -1,8 +1,8 @@
 <li>
   <p><%= lunch.scheduled_for %></p>
   <p><%= lunch.user.name %></p>
-  <% lunch.invitees.each do |invitee| %>
-    <p><%= invitee.name %></p>
+  <% lunch.attendees.each do |attendee| %>
+    <p><%= attendee.name %></p>
   <% end %>
   <%= link_to "詳細", lunch %>
 </li>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -2,7 +2,6 @@
   <p>日付</p>
   <p><%= @lunch.scheduled_for %></p>
   <p>メンバー</p>
-  <p><%= @lunch.user.name %></p>
   <% @lunch.attendees.each do |attendee| %>
     <p><%= attendee.name %></p>
   <% end %>

--- a/app/views/lunches/show.html.erb
+++ b/app/views/lunches/show.html.erb
@@ -3,8 +3,8 @@
   <p><%= @lunch.scheduled_for %></p>
   <p>メンバー</p>
   <p><%= @lunch.user.name %></p>
-  <% @lunch.invitees.each do |invitee| %>
-    <p><%= invitee.name %></p>
+  <% @lunch.attendees.each do |attendee| %>
+    <p><%= attendee.name %></p>
   <% end %>
   <% if @lunch.place.present? %>
     <p>場所</p>

--- a/db/migrate/20181005073703_rename_invitations_to_attendances.rb
+++ b/db/migrate/20181005073703_rename_invitations_to_attendances.rb
@@ -1,0 +1,5 @@
+class RenameInvitationsToAttendances < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :invitations, :attendances
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_060534) do
+ActiveRecord::Schema.define(version: 2018_10_05_073703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "invitations", force: :cascade do |t|
+  create_table "attendances", force: :cascade do |t|
     t.bigint "lunch_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["lunch_id"], name: "index_invitations_on_lunch_id"
-    t.index ["user_id"], name: "index_invitations_on_user_id"
+    t.index ["lunch_id"], name: "index_attendances_on_lunch_id"
+    t.index ["user_id"], name: "index_attendances_on_user_id"
   end
 
   create_table "lunches", force: :cascade do |t|
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_060534) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "invitations", "lunches"
+  add_foreign_key "attendances", "lunches"
   add_foreign_key "lunches", "users"
   add_foreign_key "topics", "lunches"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,20 +7,20 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 user = User.create(name: 'amy', admin: true)
-invitee = User.create!(name: 'tom')
-invitee2 = User.create!(name: 'george')
+attendee = User.create!(name: 'tom')
+attendee2 = User.create!(name: 'george')
 lunch = user.lunches.create(scheduled_for: Date.new(2018, 8, 1),
                             place: 'Asian Parm',
                             state: :scheduled)
-lunch.invite(invitee)
-lunch.invite(invitee2)
+lunch.attend(attendee)
+lunch.attend(attendee2)
 
 user = User.create(name: 'basil', admin: true)
-invitee = User.create!(name: 'baiken')
-invitee2 = User.create!(name: 'may')
+attendee = User.create!(name: 'baiken')
+attendee2 = User.create!(name: 'may')
 lunch = user.lunches.create(scheduled_for: Date.new(2018, 8, 2),
                             place: '和泉鮨🍣',
                             state: :done)
-lunch.invite(invitee)
-lunch.invite(invitee2)
+lunch.attend(attendee)
+lunch.attend(attendee2)
 lunch.create_topic(description: 'スペインの話、住んでいるところの話とか')


### PR DESCRIPTION
現在、`User`は`Lunch`の関連を直接持っています。これは主催を表現するつもりでおいたものですが、関係をシンプルにするために、`invitations`の関連で統一します。

## やること

- [x] テーブル名の変更
- [x] `User has_many Lunches`の関連を剥がす
- [x] invitationの意味が変わるので、意味が通じるようにリネームする

## やらないこと

- 誰が主催なのかがわからなくなるが、一度おいておく

## 見ていただきたいところ

- (レビューいただきたいところを書きます。)

## レビュアー

(レビュアーとして見ていただきたい人を書きます。)

## マージ条件

(マージされる条件を書きます。レビュアー１人以上のLGTMとか。)
