### PR TITLE
ランチの予定に参加者を入力できる

### DIFF
--- a/app/views/lunches/_form.html.erb
+++ b/app/views/lunches/_form.html.erb
@@ -4,6 +4,7 @@
     <% lunch.attendees.each do |attendee| %>
       <%= attendee.name %>
     <% end %>
+    <%= f.collection_check_boxes :user_ids, User.all, :id, :name %>
   </div>
   <div>
     <%= f.label "予定日" %>


### PR DESCRIPTION
ランチの登録、編集時に参加者を入力できるようにします。

## やること

- [ ] 登録時に参加者を入力できる
  - フォームに参加者を表示する
  - 入力した参加者のidsを受け取る
  - 受け取ったidsでlunchとの関連を登録する
- [ ] 編集時に参加者を修正できる

(スムーズなマージを実現するためにできる限り説明できることは説明しましょう。)

## やらないこと

- [ ] (やらないことを書きます。今は考えないことをレビュアーに伝えます。)

(スムーズなマージを実現するためにできる限り説明できることは説明しましょう。)

## 見ていただきたいところ

- (レビューいただきたいところを書きます。)

## レビュアー

(レビュアーとして見ていただきたい人を書きます。)

## マージ条件

(マージされる条件を書きます。レビュアー１人以上のLGTMとか。)
